### PR TITLE
Update README.md to better refelect library capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ function callback(err, results) {
 
 Looks up information about the given audio file.
 
-*File* must be the path to an audio file.
+*File* must be the path to an audio file or a readable stream.
 
 *Options* must be an object with the following keys:
 


### PR DESCRIPTION
The node-fpcalc library specifies that file is the path to the file or a readable stream (https://github.com/parshap/node-fpcalc)

as the file value in this module is only piped into that library we should have the same description of this value